### PR TITLE
add missing mock verification

### DIFF
--- a/src/Applications/use_case/commentlikes/_test/PutCommentLikeUseCase.test.js
+++ b/src/Applications/use_case/commentlikes/_test/PutCommentLikeUseCase.test.js
@@ -90,5 +90,6 @@ describe('PutCommentLikeUseCase', () => {
     // Action & Assert
     await expect(putCommentLikeUseCase.execute(threadId, commentId, userId))
       .rejects.toThrowError('PUT_COMMENT_LIKE_USE_CASE.EXECUTE_ERROR');
+    expect(mockCommentLikeRepository.getCommentLikeId).toBeCalledWith(commentId, userId);
   });
 });


### PR DESCRIPTION
add missing mock verification on throw error test case in PutCommentLikeUseCase.test.js at mockCommentLikeRepository.getCommentLikeId method